### PR TITLE
[EventLoop] Associate only one listener per each stream event type.

### DIFF
--- a/src/React/EventLoop/StreamSelectLoop.php
+++ b/src/React/EventLoop/StreamSelectLoop.php
@@ -82,7 +82,6 @@ class StreamSelectLoop implements LoopInterface
                     $listener = $this->readListeners[(int) $stream];
                     if (call_user_func($listener, $stream, $this) === false) {
                         $this->removeReadStream($stream);
-                        break;
                     }
                 }
             }
@@ -96,7 +95,6 @@ class StreamSelectLoop implements LoopInterface
                     $listener = $this->writeListeners[(int) $stream];
                     if (call_user_func($listener, $stream, $this) === false) {
                         $this->removeWriteStream($stream);
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
Allowing multiple listeners makes code more complex and it is beyond the scope of the whole event loop abstraction anyway.

Such a requirement could be easily satisfied on a higher level if a class wrapping the event loop needs to notify more than one listener about changes in the status of a stream resource.

See also [PR comments on the old repository](https://github.com/igorw/SocketServer/pull/41#issuecomment-5638345).
