### PR TITLE
[EventLoop] Implement timers for the stream_select() based loop.

### DIFF
--- a/src/React/EventLoop/Timer/Timers.php
+++ b/src/React/EventLoop/Timer/Timers.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace React\EventLoop\Timer;
+
+class Timers
+{
+    const MIN_RESOLUTION = 0.001;
+
+    private $time;
+    private $active;
+    private $timers;
+
+    public function __construct()
+    {
+        $this->time = 0;
+        $this->active = array();
+        $this->timers = new \SplPriorityQueue();
+    }
+
+    public function updateTime()
+    {
+        return $this->time = microtime(true);
+    }
+
+    public function getTime()
+    {
+        return $this->time ?: $this->updateTime();
+    }
+
+    public function add($interval, $callback, $periodic = false)
+    {
+        if ($interval < self::MIN_RESOLUTION) {
+            throw new \InvalidArgumentException('Timer events do not support sub-millisecond timeouts.');
+        }
+
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException('The callback must be a callable object.');
+        }
+
+        $interval = (float) $interval;
+
+        $timer = (object) array(
+            'interval' => $interval,
+            'callback' => $callback,
+            'periodic' => $periodic,
+            'scheduled' => $interval + $this->getTime(),
+        );
+
+        $signature = $timer->signature = spl_object_hash($timer);
+        $this->timers->insert($timer, -$timer->scheduled);
+        $this->active[$signature] = $timer;
+
+        return $signature;
+    }
+
+    public function cancel($signature)
+    {
+        unset($this->active[$signature]);
+    }
+
+    public function getFirst()
+    {
+        if ($this->timers->isEmpty()) {
+            return -1;
+        }
+
+        return $this->timers->top()->scheduled;
+    }
+
+    public function isEmpty()
+    {
+        return !$this->active;
+    }
+
+    public function run()
+    {
+        $time = $this->updateTime();
+        $timers = $this->timers;
+
+        while (!$timers->isEmpty() && $timers->top()->scheduled < $time) {
+            $timer = $timers->extract();
+
+            if (isset($this->active[$timer->signature])) {
+                $rearm = call_user_func($timer->callback);
+
+                if ($timer->periodic === true && $rearm !== false) {
+                    $timer->scheduled = $timer->interval + $time;
+                    $this->timers->insert($timer, -$timer->scheduled);
+                } else {
+                    unset($this->active[$timer->signature]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Timers can be one-shot or periodic and both are cancellable by using the signature returned when adding them to the event loop. Periodic timers can be cancelled also by returing `FALSE` from the provided callback.

The event loop will continue to run even without any registered stream until there is at least one timer scheduled for execution or the loop is explicitly stopped.

Certain aspects of timers are inspired by how EventMachine is internally designed. We also return a signature instead of a full-blown object for timers because this is probably the simplest way to abstract implementations that would greatly differ, such as with the libevent or libev extensions. A full-blown timer class can still be implemented on top of the event loop.

Timers can have a minimum resolution of 1ms, this value should be plenty enough. Even with 10 periodic timers set to fire an empty callback each 1ms the CPU usage is limited to ~6% using PHP 5.4.0 on the Linux VM running on my MacBook Pro.
