### PR TITLE
[EventLoop] Fix issues when removing streams with libevent.

### DIFF
--- a/src/React/EventLoop/LibEventLoop.php
+++ b/src/React/EventLoop/LibEventLoop.php
@@ -112,11 +112,16 @@ class LibEventLoop implements LoopInterface
             $event = $this->events[$id];
 
             event_del($event);
+            event_free($event);
+            unset($this->{"{$eventCallbacks}Callbacks"}[$id]);
+
+            $event = event_new();
             event_set($event, $stream, $flags | EV_PERSIST, $this->callback, $this);
+            event_base_set($event, $this->base);
             event_add($event);
 
+            $this->events[$id] = $event;
             $this->flags[$id] = $flags;
-            unset($this->{"{$eventCallbacks}Callbacks"}[$id]);
         }
     }
 
@@ -127,15 +132,15 @@ class LibEventLoop implements LoopInterface
         if (isset($this->events[$id])) {
             $event = $this->events[$id];
 
-            event_del($event);
-            event_free($event);
-
             unset(
                 $this->events[$id],
                 $this->flags[$id],
                 $this->readCallbacks[$id],
                 $this->writeCallbacks[$id]
             );
+
+            event_del($event);
+            event_free($event);
         }
     }
 


### PR DESCRIPTION
When doing two consecutive updates on an event resource inside the same tick, pecl-libevent seems to get stuck without properly freeing up the event. It is still unclear if it is something related to pecl-libevent or libevent itself, but our new approach seems to fix this problem.

For now we just delete the previous resource and create a new one one on the associated stream using the new flags.

This commit should fix issue #9.
