### PR TITLE
[WIP][Socket][Http] Encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "react/espresso": "self.version"
     },
     "autoload": {
-        "psr-0": { "React": "src" }
+        "psr-0": {
+            "React": "src",
+            "ext-mbstring": "*"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,14 +1,19 @@
 {
-    "hash": "1892e6bc3c571dfebc0734fc810b5a2c",
+    "hash": "83c0cea8d2b5033413d7e2aa83a599b9",
     "packages": [
         {
             "package": "evenement/evenement",
             "version": "dev-master",
-            "source-reference": "808e3aaea8d4f908e455b0e047cc1acc46b38d44"
+            "source-reference": "b3b308f4b124e643bb632e0a3cf5944894b7d952"
         },
         {
             "package": "guzzle/guzzle",
             "version": "v2.5.0"
+        },
+        {
+            "package": "pimple/pimple",
+            "version": "dev-master",
+            "source-reference": "v1.0.0"
         },
         {
             "package": "pimple/pimple",
@@ -18,9 +23,9 @@
             "alias-version": "1.0.9999999.9999999-dev"
         },
         {
-            "package": "pimple/pimple",
+            "package": "silex/silex",
             "version": "dev-master",
-            "source-reference": "v1.0.0"
+            "source-reference": "87e0d21c45e76af5a7ee4a96060e4c040638dd05"
         },
         {
             "package": "silex/silex",
@@ -32,14 +37,9 @@
         {
             "package": "silex/silex",
             "version": "dev-master",
-            "source-reference": "24244da60407eff5d08dd5c460a7d23285be6995",
+            "source-reference": "87e0d21c45e76af5a7ee4a96060e4c040638dd05",
             "alias-pretty-version": "1.0.x-dev",
             "alias-version": "1.0.9999999.9999999-dev"
-        },
-        {
-            "package": "silex/silex",
-            "version": "dev-master",
-            "source-reference": "24244da60407eff5d08dd5c460a7d23285be6995"
         },
         {
             "package": "symfony/browser-kit",
@@ -54,13 +54,6 @@
             "source-reference": "6ab1b5f07dd972d2c5e3b5d48c9776d0823149c7"
         },
         {
-            "package": "symfony/browser-kit",
-            "version": "dev-master",
-            "source-reference": "2cebdd6803abf9c7240bb2a7a5c3aa8f45a9ef9f",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
             "package": "symfony/class-loader",
             "version": "dev-master",
             "source-reference": "c57e62c886899f8d88264efad23c857eb198dc09"
@@ -73,16 +66,9 @@
             "alias-version": "2.1.9999999.9999999-dev"
         },
         {
-            "package": "symfony/class-loader",
-            "version": "dev-master",
-            "source-reference": "0e6ee8d07dda6920106048247d41249201604e76",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
             "package": "symfony/css-selector",
             "version": "dev-master",
-            "source-reference": "282a6ed63e542463240fc21db96babdbdc889271"
+            "source-reference": "b542ab7df00bc12b8fa7fe318e399522bc873485"
         },
         {
             "package": "symfony/css-selector",
@@ -94,7 +80,7 @@
         {
             "package": "symfony/css-selector",
             "version": "dev-master",
-            "source-reference": "83009868bc7be01f7ba84c55edf085482b5da7a5",
+            "source-reference": "b542ab7df00bc12b8fa7fe318e399522bc873485",
             "alias-pretty-version": "2.1.x-dev",
             "alias-version": "2.1.9999999.9999999-dev"
         },
@@ -108,19 +94,14 @@
         {
             "package": "symfony/dom-crawler",
             "version": "dev-master",
-            "source-reference": "49d80fac919321c1e255757fe47b97910f667271",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "source-reference": "49d80fac919321c1e255757fe47b97910f667271"
         },
         {
             "package": "symfony/dom-crawler",
             "version": "dev-master",
-            "source-reference": "49d80fac919321c1e255757fe47b97910f667271"
-        },
-        {
-            "package": "symfony/event-dispatcher",
-            "version": "dev-master",
-            "source-reference": "eb82542e8ec9506096caf7c528564c740a214f56"
+            "source-reference": "49d80fac919321c1e255757fe47b97910f667271",
+            "alias-pretty-version": "2.1.x-dev",
+            "alias-version": "2.1.9999999.9999999-dev"
         },
         {
             "package": "symfony/event-dispatcher",
@@ -132,14 +113,12 @@
         {
             "package": "symfony/event-dispatcher",
             "version": "dev-master",
-            "source-reference": "0c1ae4898196f5e96b79028d8d2f35de4b584659",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "source-reference": "eb82542e8ec9506096caf7c528564c740a214f56"
         },
         {
             "package": "symfony/finder",
             "version": "dev-master",
-            "source-reference": "a464fd63f0b1bf0feef1ea1dd9642728c2c2060a"
+            "source-reference": "a2cef64d5072b284b671ee8e06b8ebc38c2969e1"
         },
         {
             "package": "symfony/finder",
@@ -151,14 +130,9 @@
         {
             "package": "symfony/finder",
             "version": "dev-master",
-            "source-reference": "19ef3c1ca88f6e69d9cca0eda2e3a20f85e0173a",
+            "source-reference": "a2cef64d5072b284b671ee8e06b8ebc38c2969e1",
             "alias-pretty-version": "2.1.x-dev",
             "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/http-foundation",
-            "version": "dev-master",
-            "source-reference": "3d9f4ce435f6322b9720c209ad610202526373c0"
         },
         {
             "package": "symfony/http-foundation",
@@ -170,9 +144,19 @@
         {
             "package": "symfony/http-foundation",
             "version": "dev-master",
-            "source-reference": "54c22f4bf8625303503a117dcc68544d3f8ac876",
+            "source-reference": "5b1581418381f46679604fd19efc8b518f2390ae"
+        },
+        {
+            "package": "symfony/http-foundation",
+            "version": "dev-master",
+            "source-reference": "5b1581418381f46679604fd19efc8b518f2390ae",
             "alias-pretty-version": "2.1.x-dev",
             "alias-version": "2.1.9999999.9999999-dev"
+        },
+        {
+            "package": "symfony/http-kernel",
+            "version": "dev-master",
+            "source-reference": "8160e6e1722cd0073152d01dc1464e2e23369484"
         },
         {
             "package": "symfony/http-kernel",
@@ -184,12 +168,14 @@
         {
             "package": "symfony/http-kernel",
             "version": "dev-master",
-            "source-reference": "e2e0789f90d1078839bb9448d2ac831e944fc2aa"
+            "source-reference": "8160e6e1722cd0073152d01dc1464e2e23369484",
+            "alias-pretty-version": "2.1.x-dev",
+            "alias-version": "2.1.9999999.9999999-dev"
         },
         {
-            "package": "symfony/http-kernel",
+            "package": "symfony/process",
             "version": "dev-master",
-            "source-reference": "94abcb71a634d7fc0e1eac287cbc1f7d1792d367",
+            "source-reference": "106f2db51cecf2fe5ee59e428b8f4a918c4034fa",
             "alias-pretty-version": "2.1.x-dev",
             "alias-version": "2.1.9999999.9999999-dev"
         },
@@ -206,11 +192,16 @@
             "source-reference": "106f2db51cecf2fe5ee59e428b8f4a918c4034fa"
         },
         {
-            "package": "symfony/process",
+            "package": "symfony/routing",
             "version": "dev-master",
-            "source-reference": "106f2db51cecf2fe5ee59e428b8f4a918c4034fa",
+            "source-reference": "aec133671d79d530d09aa0b5ca4cea9e4ee4b274",
             "alias-pretty-version": "2.1.x-dev",
             "alias-version": "2.1.9999999.9999999-dev"
+        },
+        {
+            "package": "symfony/routing",
+            "version": "dev-master",
+            "source-reference": "aec133671d79d530d09aa0b5ca4cea9e4ee4b274"
         },
         {
             "package": "symfony/routing",
@@ -218,18 +209,6 @@
             "source-reference": "b6c2bafae0cf8a557d719598a4a462676c3d04bd",
             "alias-pretty-version": "2.1.x-dev",
             "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/routing",
-            "version": "dev-master",
-            "source-reference": "836d9bb95861cbb58bbb37799e6be27427715eaa",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/routing",
-            "version": "dev-master",
-            "source-reference": "836d9bb95861cbb58bbb37799e6be27427715eaa"
         }
     ],
     "packages-dev": null,

--- a/src/React/Http/RequestHeaderParser.php
+++ b/src/React/Http/RequestHeaderParser.php
@@ -12,7 +12,7 @@ class RequestHeaderParser extends EventEmitter
 
     public function feed($data)
     {
-        if (strlen($this->buffer) + strlen($data) > $this->maxSize) {
+        if (mb_strlen($this->buffer, '8bit') + mb_strlen($data, '8bit') > $this->maxSize) {
             $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded."), $this));
 
             return;
@@ -20,7 +20,7 @@ class RequestHeaderParser extends EventEmitter
 
         $this->buffer .= $data;
 
-        if (false !== strpos($this->buffer, "\r\n\r\n")) {
+        if (false !== mb_strpos($this->buffer, "\r\n\r\n", 0, 'ASCII')) {
             list($request, $bodyBuffer) = $this->parseRequest($this->buffer);
 
             $this->emit('headers', array($request, $bodyBuffer));
@@ -36,9 +36,9 @@ class RequestHeaderParser extends EventEmitter
         $parsed = $factory->parseMessage($headers."\r\n\r\n");
 
         $parsedQuery = array();
-        if (0 === strpos($parsed['parts']['query'], '?')) {
-            $query = substr($parsed['parts']['query'], 1);
-            parse_str($query, $parsedQuery);
+        if (0 === mb_strpos($parsed['parts']['query'], '?', 0, 'ASCII')) {
+            $query = mb_substr($parsed['parts']['query'], 1, mb_strlen($parsed['parts']['query'], 'ASCII'), 'ASCII');
+            mb_parse_str($query, $parsedQuery);
         }
 
         $request = new Request(

--- a/src/React/Http/Response.php
+++ b/src/React/Http/Response.php
@@ -46,7 +46,7 @@ class Response extends EventEmitter
         }
 
         if ($this->chunkedEncoding) {
-            $len = strlen($data);
+            $len = mb_strlen($data, '8bit');
             $chunk = dechex($len)."\r\n".$data."\r\n";
             $this->conn->write($chunk);
         } else {

--- a/src/React/Http/composer.json
+++ b/src/React/Http/composer.json
@@ -9,7 +9,10 @@
         "react/socket": "dev-master"
     },
     "autoload": {
-        "psr-0": { "React\\Http": "" }
+        "psr-0": {
+            "React\\Http": "",
+            "ext-mbstring": "*"
+        }
     },
     "target-dir": "React/Http"
 }

--- a/src/React/Socket/Buffer.php
+++ b/src/React/Socket/Buffer.php
@@ -76,7 +76,7 @@ class Buffer extends EventEmitter
             return;
         }
 
-        $this->data = substr($this->data, $sent);
+        $this->data = mb_substr($this->data, $sent, mb_strlen($this->data, '8bit'), '8bit');
 
         if (0 === strlen($this->data)) {
             $this->emit('end');

--- a/src/React/Socket/composer.json
+++ b/src/React/Socket/composer.json
@@ -9,7 +9,10 @@
         "react/event-loop": "dev-master"
     },
     "autoload": {
-        "psr-0": { "React\\Socket": "" }
+        "psr-0": {
+            "React\\Socket": "",
+            "ext-mbstring": "*"
+        }
     },
     "target-dir": "React/Socket"
 }

--- a/tests/React/Tests/Http/ResponseTest.php
+++ b/tests/React/Tests/Http/ResponseTest.php
@@ -61,6 +61,10 @@ class ResponseTest extends TestCase
         $conn
             ->expects($this->at(4))
             ->method('write')
+            ->with("3\r\n✓\r\n");
+        $conn
+            ->expects($this->at(5))
+            ->method('write')
             ->with("0\r\n\r\n");
 
         $response = new Response($conn);
@@ -69,6 +73,7 @@ class ResponseTest extends TestCase
         $response->write('Hello');
         $response->write(' ');
         $response->write("World\n");
+        $response->write('✓');
         $response->end();
     }
 }


### PR DESCRIPTION
I should probably add a couple more unit tests before this is merged.

This is a difficult scenario to test against.  To see why mbstring is required, do the following: In php.ini set the following parameters:

> mbstring.internal_encoding = UTF-8
> mbstring.func_overload = 7

And add the unit test in this PR against React's master branch (but not the rest of the code) and run phpunit. It will fail under these common ini settings. 

Developers are taught to use UTF-8 for encoding, which is good.  React deals a the low byte level, where Unicode and UTF-8 are not desired. Characters, such as ✓, can be stored in more than one byte of data, while being represented as a single character.  In most scenarios we'd want to handle it as a single character, but in dealing with I/O we need to make sure we handle it as 3 characters. That's what this PR addresses. 
