### PR TITLE
[Socket] shutdown on end

### DIFF
--- a/src/React/Socket/Connection.php
+++ b/src/React/Socket/Connection.php
@@ -47,6 +47,7 @@ class Connection extends EventEmitter implements ConnectionInterface
         $this->buffer->removeAllListeners();
         $this->removeAllListeners();
         if (is_resource($this->socket)) {
+            stream_socket_shutdown($this->socket, STREAM_SHUT_WR);
             fclose($this->socket);
         }
         $this->closed = true;


### PR DESCRIPTION
Calling stream_socket_shutdown when closing a client
close is often too slow or doesn't always notify the client that
the connection is closed.
stream_socket_shutdown will immediately drop the TCP peer
