### PR TITLE
Add two new examples: shitload of data, tcp chat

### DIFF
--- a/examples/pump-shitload-of-data.php
+++ b/examples/pump-shitload-of-data.php
@@ -1,0 +1,23 @@
+<?php
+
+// serve a lot of data over TCP
+// useful for profiling
+// you can run this command to profile with xdebug:
+// php -d xdebug.profiler_enable=on examples/pump-shitload-of-data.php
+
+require __DIR__.'/../vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+$socket = new React\Socket\Server($loop);
+
+$socket->on('connect', function ($conn) {
+    $shitload = str_repeat('a', 1024*1024*32);
+    $conn->write($shitload);
+    $conn->end();
+});
+
+echo "Socket server listening on port 4000.\n";
+echo "You can connect to it by running: telnet localhost 4000\n";
+
+$socket->listen(4000);
+$loop->run();

--- a/examples/tcp-chat.php
+++ b/examples/tcp-chat.php
@@ -1,0 +1,34 @@
+<?php
+
+// socket based chat
+
+require __DIR__.'/../vendor/autoload.php';
+
+$loop = React\EventLoop\Factory::create();
+$socket = new React\Socket\Server($loop);
+
+$conns = new \SplObjectStorage();
+
+$socket->on('connection', function ($conn) use ($conns) {
+    $conns->attach($conn);
+
+    $conn->on('data', function ($data) use ($conns, $conn) {
+        foreach ($conns as $current) {
+            if ($conn === $current) {
+                continue;
+            }
+
+            $current->write($data);
+        }
+    });
+
+    $conn->on('end', function () use ($conns, $conn) {
+        $conns->detach($conn);
+    });
+});
+
+echo "Socket server listening on port 4000.\n";
+echo "You can connect to it by running: telnet localhost 4000\n";
+
+$socket->listen(4000);
+$loop->run();


### PR DESCRIPTION
- Shitload of data can be useful to bench and profile data transmission.
  It sends 32MiB to the connected TCP client.
- TCP chat shows how you can use SplObjectStorage to keep track of
  connections, and broadcast messages.
