### PR TITLE
Added Icon.png to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+Icon.png


### PR DESCRIPTION
Icon.png is read by the Git application Tower to provide a logo.  Instead of polluting the repository, we're just adding it to the ignore so those who want the icon can drop their own in.
