### PR TITLE
handle write errors in Stream Buffer

### DIFF
--- a/src/React/Stream/Buffer.php
+++ b/src/React/Stream/Buffer.php
@@ -83,7 +83,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         restore_error_handler();
 
-        if (false === $sent) {
+        if (false === $sent || feof($this->stream)) {
             $this->emit('error', array(new \ErrorException(
                 $this->lastError['message'],
                 0,

--- a/tests/React/Tests/Stream/BufferTest.php
+++ b/tests/React/Tests/Stream/BufferTest.php
@@ -59,6 +59,25 @@ class BufferTest extends TestCase
      * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::handleWrite
      */
+    public function testWriteDetectsWhenOtherSideIsClosed()
+    {
+        list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+
+        $loop = $this->createWriteableLoopMock();
+
+        $buffer = new Buffer($a, $loop);
+        $buffer->softLimit = 4;
+        $buffer->on('error', $this->expectCallableOnce());
+
+        fclose($b);
+
+        $buffer->write("foo");
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
+     * @covers React\Stream\Buffer::handleWrite
+     */
     public function testDrain()
     {
         $stream = fopen('php://temp', 'r+');


### PR DESCRIPTION
This handles two issues:

When a write fails (fwrite returns false because the stream isn't open anymore), Buffer doesn't remove the stream from the event loop

And when the other side of a socket is closed, Buffer may not notice it and won't emit an error event
