### PR TITLE
Append minimum-stability to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The recommended way to install react is [through composer](http://getcomposer.or
 
 ```JSON
 {
+    "minimum-stability": "dev",
     "require": {
         "react/react": "0.1.*"
     }


### PR DESCRIPTION
Currently react/react can't be installed without this setting.
