### PR TITLE
PHP Fatal error:  Wrong parameters for ErrorException

### DIFF
--- a/src/React/Stream/Buffer.php
+++ b/src/React/Stream/Buffer.php
@@ -15,10 +15,10 @@ class Buffer extends EventEmitter implements WritableStreamInterface
     private $loop;
     private $data = '';
     private $lastError = array(
-        'number'  => '',
+        'number'  => 0,
         'message' => '',
         'file'    => '',
-        'line'    => '',
+        'line'    => 0,
     );
 
     public function __construct($stream, LoopInterface $loop)


### PR DESCRIPTION
if    feof($this->stream) is true
default value of   $lastError = array(
        'number'  => '',
        'message' => '',
        'file'    => '',
        'line'    => '',
    );
the parameters of ErrorException::__construct is 
[string $exception [, long $code, [ long $severity, [ string $filename, [ long $lineno  [, Exception $previous = NULL]]]]]]
the type is wrong and will cause a error.
