### PR TITLE
Rename $resolver to $dns in examples

### DIFF
--- a/examples/dns-resolver.php
+++ b/examples/dns-resolver.php
@@ -6,11 +6,11 @@ require __DIR__.'/../vendor/autoload.php';
 
 $loop = React\EventLoop\Factory::create();
 $factory = new React\Dns\Resolver\Factory();
-$resolver = $factory->create('8.8.8.8', $loop);
+$dns = $factory->create('8.8.8.8', $loop);
 
 $domain = 'igor.io';
 
-$resolver->resolve($domain, function ($ip) {
+$dns->resolve($domain, function ($ip) {
     echo "Host: $ip\n";
 });
 

--- a/src/React/Dns/README.md
+++ b/src/React/Dns/README.md
@@ -14,9 +14,9 @@ names, baby!
 
     $loop = React\EventLoop\Factory::create();
     $factory = new React\Dns\Resolver\Factory();
-    $resolver = $factory->create('8.8.8.8', $loop);
+    $dns = $factory->create('8.8.8.8', $loop);
 
-    $resolver->resolve('igor.io', function ($ip) {
+    $dns->resolve('igor.io', function ($ip) {
         echo "Host: $ip\n";
     });
 
@@ -28,15 +28,15 @@ You can cache results by configuring the resolver to use a `CachedExecutor`:
 
     $loop = React\EventLoop\Factory::create();
     $factory = new React\Dns\Resolver\Factory();
-    $resolver = $factory->createCached('8.8.8.8', $loop);
+    $dns = $factory->createCached('8.8.8.8', $loop);
 
-    $resolver->resolve('igor.io', function ($ip) {
+    $dns->resolve('igor.io', function ($ip) {
         echo "Host: $ip\n";
     });
 
     ...
 
-    $resolver->resolve('igor.io', function ($ip) {
+    $dns->resolve('igor.io', function ($ip) {
         echo "Host: $ip\n";
     });
 


### PR DESCRIPTION
This is partially to prevent clashes in the future with React/Promise,
which includes a separate concept of resolvers.

It also is more intuitive to newcomers, and reads nicer in general.
