### PR TITLE
memory leak issue, closes #76

### DIFF
--- a/src/React/EventLoop/LibEventLoop.php
+++ b/src/React/EventLoop/LibEventLoop.php
@@ -185,6 +185,9 @@ class LibEventLoop implements LoopInterface
                 if ($timer->periodic === true) {
                     event_add($timer->resource, $timer->interval);
                 }
+                else {
+                    $this->cancelTimer($timer->signature);
+                }
             }
         };
 


### PR DESCRIPTION
For non-periodic timers, they will now be cleaned up via cancelTimer method.
