### PR TITLE
React\Http\Response emits 'end' event when stream is ended

### DIFF
--- a/src/React/Http/Response.php
+++ b/src/React/Http/Response.php
@@ -98,7 +98,7 @@ class Response extends EventEmitter implements WritableStreamInterface
             $this->conn->write("0\r\n\r\n");
         }
 
-        $this->emit('close');
+        $this->emit('end');
         $this->removeAllListeners();
         $this->conn->end();
     }

--- a/tests/React/Tests/Http/ResponseTest.php
+++ b/tests/React/Tests/Http/ResponseTest.php
@@ -71,6 +71,19 @@ class ResponseTest extends TestCase
         $response->write("World\n");
         $response->end();
     }
+    
+    public function testResponseShouldEmitEndOnStreamEnd(){
+      $conn = $this->getMock('React\Socket\ConnectionInterface');
+      $response = new Response( $conn );
+      $ended = false;
+      $response->on( 'end', function() use (&$ended){
+        $ended = true;
+      });
+      $response->end();
+      
+      $this->assertTrue( $ended, "Response did not emit 'end'" );
+      
+    }
 
     /** @test */
     public function writeContinueShouldSendContinueLineBeforeRealHeaders()


### PR DESCRIPTION
Response was incorrectly emitting the 'close' event.
