### PR TITLE
[EventLoop] Fix timers when using libevent-based loop.

### DIFF
--- a/tests/React/Tests/EventLoop/Timer/LibEventTimerTest.php
+++ b/tests/React/Tests/EventLoop/Timer/LibEventTimerTest.php
@@ -14,9 +14,4 @@ class LibEventTimerTest extends AbstractTimerTest
 
         return new LibEventLoop();
     }
-
-    public function testAddPeriodicTimerCancelsItself()
-    {
-        $this->markTestSkipped('libevent timers are currently broken.');
-    }
 }


### PR DESCRIPTION
Since a closure cannot destroy itself from inside its body, to prevent PHP from raising the fatal error _Cannot destroy active lambda function_ when cancelling a periodic timer from inside its callback we previously tried to postpone the call to `event_free()` on the affected libevent timer resource at a later stage by queueing up timer resources to be freed. This approach was quite awkward and eventually lead to complex code, difficult to test and with other unexpected side effects such as memory leaks in a couple of corner cases.

This new fix greatly reduces code complexity and makes it possible to free up timer resources immediatly when cancelling a timer: we simply keep a reference of our internal timer callback from inside itself so that its refcount is still > 1 when calling `event_free()`, effectively preventing PHP's garbage collector to kick in when the closure is still active.
