### PR TITLE
[EventLoop] Remove check on return value from streams callbacks.

### DIFF
--- a/src/React/EventLoop/LibEventLoop.php
+++ b/src/React/EventLoop/LibEventLoop.php
@@ -32,15 +32,11 @@ class LibEventLoop implements LoopInterface
 
             try {
                 if (($flags & EV_READ) === EV_READ && isset($readCallbacks[$id])) {
-                    if (call_user_func($readCallbacks[$id], $stream, $loop) === false) {
-                        $loop->removeReadStream($stream);
-                    }
+                    call_user_func($readCallbacks[$id], $stream, $loop);
                 }
 
                 if (($flags & EV_WRITE) === EV_WRITE && isset($writeCallbacks[$id])) {
-                    if (call_user_func($writeCallbacks[$id], $stream, $loop) === false) {
-                        $loop->removeWriteStream($stream);
-                    }
+                    call_user_func($writeCallbacks[$id], $stream, $loop);
                 }
             } catch (\Exception $ex) {
                 // If one of the callbacks throws an exception we must stop the loop

--- a/src/React/EventLoop/StreamSelectLoop.php
+++ b/src/React/EventLoop/StreamSelectLoop.php
@@ -125,9 +125,7 @@ class StreamSelectLoop implements LoopInterface
             if ($read) {
                 foreach ($read as $stream) {
                     $listener = $this->readListeners[(int) $stream];
-                    if (call_user_func($listener, $stream, $this) === false) {
-                        $this->removeReadStream($stream);
-                    }
+                    call_user_func($listener, $stream, $this);
                 }
             }
 
@@ -138,9 +136,7 @@ class StreamSelectLoop implements LoopInterface
                     }
 
                     $listener = $this->writeListeners[(int) $stream];
-                    if (call_user_func($listener, $stream, $this) === false) {
-                        $this->removeWriteStream($stream);
-                    }
+                    call_user_func($listener, $stream, $this);
                 }
             }
         }


### PR DESCRIPTION
This was an early addition but now that the event loop abstraction is mature enough it's definitely better to be explicit when removing a stream instead of relying on obscure values returned from callbacks.
