### PR TITLE
Change react/promise constraints to use tilde operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "evenement/evenement": "1.0.*",
         "guzzle/http": "3.0.*",
         "guzzle/parser": "3.0.*",
-        "react/promise": "1.0.*"
+        "react/promise": "~1.0"
     },
     "require-dev": {
         "ext-libevent": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "db8f254e657053a020cd6117714b6f49",
+    "hash": "7785a9ee5fc85ae8976c518c00011bcd",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -20,7 +20,6 @@
             },
             "time": "2012-05-30 08:01:08",
             "type": "library",
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Evenement": "src"
@@ -62,12 +61,12 @@
             },
             "time": "2012-11-12 00:00:24",
             "type": "library",
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Guzzle\\Common": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -103,12 +102,12 @@
             },
             "time": "2012-11-11 23:54:57",
             "type": "library",
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Guzzle\\Http": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -149,12 +148,12 @@
             },
             "time": "2012-11-01 18:03:45",
             "type": "library",
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Guzzle\\Parser": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -189,12 +188,12 @@
             },
             "time": "2012-11-11 23:54:57",
             "type": "library",
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Guzzle\\Stream": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -237,7 +236,6 @@
                     "dev-master": "1.0-dev"
                 }
             },
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "React\\Promise": "src/"
@@ -288,12 +286,12 @@
                     "dev-master": "2.1-dev"
                 }
             },
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\EventDispatcher": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -311,7 +309,9 @@
             "homepage": "http://symfony.com"
         }
     ],
-    "packages-dev": null,
+    "packages-dev": [
+
+    ],
     "aliases": [
 
     ],

--- a/src/React/Cache/composer.json
+++ b/src/React/Cache/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.2",
-        "react/promise": "1.0.*"
+        "react/promise": "~1.0"
     },
     "autoload": {
         "psr-0": { "React\\Cache": "" }

--- a/src/React/Dns/composer.json
+++ b/src/React/Dns/composer.json
@@ -7,7 +7,7 @@
         "php": ">=5.3.2",
         "react/cache": "0.2.*",
         "react/socket": "0.2.*",
-        "react/promise": "1.0.*"
+        "react/promise": "~1.0"
     },
     "autoload": {
         "psr-0": { "React\\Dns": "" }

--- a/src/React/Stream/composer.json
+++ b/src/React/Stream/composer.json
@@ -9,7 +9,7 @@
     },
     "suggest": {
         "react/event-loop": "0.2.*",
-        "react/promise": "1.0.*"
+        "react/promise": "~1.0"
     },
     "autoload": {
         "psr-0": { "React\\Stream": "" }


### PR DESCRIPTION
This is equivalent of `1.*`, which will give the latest version of the `react/promise` 1.0 branch. It will remain BC using semantic versioning.
