### PR TITLE
Introducing a wrapper to the Guzzle oAuth plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "php": ">=5.3.3",
         "evenement/evenement": "1.0.*",
         "guzzle/http": "3.0.*",
+        "guzzle/plugin-oauth": "3.0.*",
         "guzzle/parser": "3.0.*",
         "react/promise": "~1.0"
     },

--- a/src/React/HttpClient/Authentication/Oauth.php
+++ b/src/React/HttpClient/Authentication/Oauth.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace React\HttpClient\Authentication;
+
+use Guzzle\Plugin\Oauth\OauthPlugin;
+use Guzzle\Common\Event;
+use Guzzle\Http\Message\Request as GuzzleRequest;
+
+/**
+ * A class wrapper for the Guzzle oAuth plugin
+ */
+class Oauth
+{
+    /**
+     * @var Guzzle\Plugin\Oauth\OauthPlugin
+     */
+    protected $oAuthPlugin;
+
+    public function __construct($config)
+    {
+        $this->oAuthPlugin = new OauthPlugin($config);
+    }
+
+    /**
+     * This method runs the actual Guzzle oAuth plugin
+     *
+     * @param \Guzzle\Http\Message\Request $request
+     * @return array
+     */
+    public function onWritingHeaders(GuzzleRequest $request)
+    {
+        $event = new Event(array('request' => $request));
+        return $this->oAuthPlugin->onRequestBeforeSend($event);
+    }
+}

--- a/src/React/HttpClient/Request.php
+++ b/src/React/HttpClient/Request.php
@@ -14,6 +14,7 @@ use React\Stream\Stream;
 use React\Stream\WritableStreamInterface;
 
 /**
+ * @event writing-headers
  * @event headers-written
  * @event response
  */
@@ -62,6 +63,8 @@ class Request extends EventEmitter implements WritableStreamInterface
             ->connect()
             ->then(
                 function ($stream) use ($that, $request, &$streamRef, &$stateRef) {
+                    $that->emit('writing-headers', array($request));
+
                     $streamRef = $stream;
 
                     $stream->on('drain', array($that, 'handleDrain'));


### PR DESCRIPTION
I was toying around with the React HttpClient, and found that it lacked the support for oAuth.

I would like to hear your thoughts and feedback on this.

Some example code:

``` php
<?php

require_once 'vendor/autoload.php';

$loop = React\EventLoop\Factory::create();

$resolverFactory = new React\Dns\Resolver\Factory();
$httpClientFactory = new React\HttpClient\Factory();

$dnsResolver = $resolverFactory->createCached('8.8.8.8', $loop);
$client = $httpClientFactory->create($loop, $dnsResolver);

$oauth = new React\HttpClient\Authentication\Oauth(array(
    'consumer_key' => '...',
    'consumer_secret' => '...',
    'token' => '...',
    'token_secret' => '...'
));

$request = $client->request('GET', 'https://stream.twitter.com/1.1/statuses/sample.json');
$request->on('response', function($response) {
    $response->on('data', function($data) {
        echo $data;
    });
});
$request->on('writing-headers', array($oauth, 'onWritingHeaders'));
$request->end();
$loop->run();

```
