### PR TITLE
[SocketClient] Remove ConnectorInterface::createUdp

### DIFF
--- a/UPGRADE-0.3.md
+++ b/UPGRADE-0.3.md
@@ -22,7 +22,7 @@ HttpClient
 ----------
 
 * `HttpClient\*ConnectionManager` has been moved to `SocketClient\*Connector`,
-  and the `getConnection` method has been renamed to `createTcp`.
+  and the `getConnection` method has been renamed to `create`.
 
   Before:
 
@@ -30,4 +30,4 @@ HttpClient
 
   After:
 
-    $connector->createTcp($host, $port);
+    $connector->create($host, $port);

--- a/src/React/HttpClient/Request.php
+++ b/src/React/HttpClient/Request.php
@@ -218,7 +218,7 @@ class Request extends EventEmitter implements WritableStreamInterface
         $port = $this->requestData->getPort();
 
         return $this->connector
-            ->createTcp($host, $port);
+            ->create($host, $port);
     }
 
     public function setResponseFactory($factory)

--- a/src/React/SocketClient/Connector.php
+++ b/src/React/SocketClient/Connector.php
@@ -19,7 +19,7 @@ class Connector implements ConnectorInterface
         $this->resolver = $resolver;
     }
 
-    public function createTcp($host, $port)
+    public function create($host, $port)
     {
         $that = $this;
 

--- a/src/React/SocketClient/ConnectorInterface.php
+++ b/src/React/SocketClient/ConnectorInterface.php
@@ -4,5 +4,5 @@ namespace React\SocketClient;
 
 interface ConnectorInterface
 {
-    public function createTcp($host, $port);
+    public function create($host, $port);
 }

--- a/src/React/SocketClient/README.md
+++ b/src/React/SocketClient/README.md
@@ -34,13 +34,13 @@ $dns = $dnsResolverFactory->createCached('8.8.8.8', $loop);
 ### Async TCP/IP connections
 
 The `React\SocketClient\Connector` provides a single promise-based
-`createTcp($host, $ip)` method which resolves as soon as the connection
+`create($host, $ip)` method which resolves as soon as the connection
 succeeds or fails.
 
 ```php
 $connector = new React\SocketClient\Connector($loop, $dns);
 
-$connector->createTcp('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
+$connector->create('www.google.com', 80)->then(function (React\Stream\Stream $stream) {
     $stream->write('...');
     $stream->close();
 });
@@ -50,13 +50,13 @@ $connector->createTcp('www.google.com', 80)->then(function (React\Stream\Stream 
 
 The `SecureConnector` class decorates a given `Connector` instance by enabling
 SSL/TLS encryption as soon as the raw TCP/IP connection succeeds. It provides
-the same promise- based `createTcp($host, $ip)` method which resolves with
+the same promise- based `create($host, $ip)` method which resolves with
 a `Stream` instance that can be used just like any non-encrypted stream.
 
 ```php
 $secureConnector = new React\SocketClient\SecureConnector($connector, $loop);
 
-$secureConnector->createTcp('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
+$secureConnector->create('www.google.com', 443)->then(function (React\Stream\Stream $stream) {
     $stream->write("GET / HTTP/1.0\r\nHost: www.google.com\r\n\r\n");
     ...
 });

--- a/src/React/SocketClient/SecureConnector.php
+++ b/src/React/SocketClient/SecureConnector.php
@@ -19,10 +19,10 @@ class SecureConnector implements ConnectorInterface
         $this->streamEncryption = new StreamEncryption($loop);
     }
 
-    public function createTcp($host, $port)
+    public function create($host, $port)
     {
         $streamEncryption = $this->streamEncryption;
-        return $this->connector->createTcp($host, $port)->then(function (Stream $stream) use ($streamEncryption) {
+        return $this->connector->create($host, $port)->then(function (Stream $stream) use ($streamEncryption) {
             // (unencrypted) connection succeeded => try to enable encryption
             return $streamEncryption->enable($stream)->then(null, function ($error) use ($stream) {
                 // establishing encryption failed => close invalid connection and return error

--- a/tests/React/Tests/HttpClient/RequestTest.php
+++ b/tests/React/Tests/HttpClient/RequestTest.php
@@ -391,7 +391,7 @@ class RequestTest extends TestCase
     {
         $this->connector
             ->expects($this->once())
-            ->method('createTcp')
+            ->method('create')
             ->with('www.example.com', 80)
             ->will($this->returnValue(new FulfilledPromise($this->stream)));
     }
@@ -400,7 +400,7 @@ class RequestTest extends TestCase
     {
         $this->connector
             ->expects($this->once())
-            ->method('createTcp')
+            ->method('create')
             ->with('www.example.com', 80)
             ->will($this->returnValue(new RejectedPromise(new \RuntimeException())));
     }

--- a/tests/React/Tests/SocketClient/ConnectorTest.php
+++ b/tests/React/Tests/SocketClient/ConnectorTest.php
@@ -17,7 +17,7 @@ class ConnectorTest extends TestCase
         $dns = $this->createResolverMock();
 
         $connector = new Connector($loop, $dns);
-        $connector->createTcp('127.0.0.1', 9999)
+        $connector->create('127.0.0.1', 9999)
                 ->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         $loop->run();
@@ -40,7 +40,7 @@ class ConnectorTest extends TestCase
         $dns = $this->createResolverMock();
 
         $connector = new Connector($loop, $dns);
-        $connector->createTcp('127.0.0.1', 9999)
+        $connector->create('127.0.0.1', 9999)
                 ->then(function ($stream) use (&$capturedStream) {
                     $capturedStream = $stream;
                     $stream->end();


### PR DESCRIPTION
It does not make sense to represent UDP as a stream. Streams have end
semantics, UDP does not.
