### PR TITLE
[Socket] Fix listening on IPv6 addresses

### DIFF
--- a/src/React/Socket/Server.php
+++ b/src/React/Socket/Server.php
@@ -18,6 +18,11 @@ class Server extends EventEmitter implements ServerInterface
 
     public function listen($port, $host = '127.0.0.1')
     {
+        if (strpos($host, ':') !== false) {
+            // enclose IPv6 addresses in square brackets before appending port
+            $host = '[' . $host . ']';
+        }
+
         $this->master = @stream_socket_server("tcp://$host:$port", $errno, $errstr);
         if (false === $this->master) {
             $message = "Could not bind to tcp://$host:$port: $errstr";


### PR DESCRIPTION
This simple patch adds support for listening on IPv6 addresses. IPv6 addresses need to be enclosed in square brackets if a port is appended.
