### PR TITLE
WIP: [Socket] Connection should use fread() instead of socket_recv_from()

### DIFF
--- a/src/React/Socket/Connection.php
+++ b/src/React/Socket/Connection.php
@@ -13,7 +13,7 @@ class Connection extends Stream implements ConnectionInterface
 {
     public function handleData($stream)
     {
-        $data = stream_socket_recvfrom($stream, $this->bufferSize);
+        $data = fread($stream, $this->bufferSize);
         if ('' === $data || false === $data) {
             $this->end();
         } else {


### PR DESCRIPTION
Currently, the `Connection` can not be used when using SSL connections. It internally uses `socket_recv_from()` which bypasses the SSL wrapper and thus returns the raw encrypted data stream instead of the decrypted payload stream.

I'm marking this as WIP, because I suspect `socket_recv_from()` was used intentionally and this change might possibly break something. All provided unit tests pass as-is, so I'm not entirely sure.
