### PR TITLE
Update LoopInterface object visibility

### DIFF
--- a/src/React/Socket/Server.php
+++ b/src/React/Socket/Server.php
@@ -9,7 +9,7 @@ use React\EventLoop\LoopInterface;
 class Server extends EventEmitter implements ServerInterface
 {
     public $master;
-    private $loop;
+    protected $loop;
 
     public function __construct(LoopInterface $loop)
     {


### PR DESCRIPTION
I am making a project based on React, and I want extend React\Socket\Connection and use how default, unchanging the React original code. But for it I have to extend React\Socket\Server and overwrite createConnection(), and the $loop need be protected to pass it for a new connection.
