### PR TITLE
[Http] Extend Response

### DIFF
--- a/src/React/Http/Response.php
+++ b/src/React/Http/Response.php
@@ -74,6 +74,8 @@ class Response extends EventEmitter implements WritableStreamInterface
             throw new \Exception('Response head has already been written.');
         }
 
+        $this->emit('header');
+
         $headers = array_merge(
             $this->headers,
             $headers

--- a/tests/React/Tests/Http/ResponseTest.php
+++ b/tests/React/Tests/Http/ResponseTest.php
@@ -230,4 +230,20 @@ class ResponseTest extends TestCase
         $response->setHeader('X-Test-Header', 'foo');
         $response->writeHead(200, array('X-Test-Header' => 'bar'));
     }
+
+    /** @test */
+    public function responseShouldEmitHeaderOnWriteHead()
+    {
+        $called = false;
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $response = new Response($conn);
+
+        $response->on('header', function () use (&$called) {
+            $called = true;
+        });
+        $response->writeHead();
+
+        $this->assertTrue($called);
+    }
 }


### PR DESCRIPTION
Use case could be for example a session middleware:

``` php
function ($request, $response) {
    // Read session cookie from $request, create session, etc...

    $response->on('header', function() use ($response) {
        $reponse->setHeader('Set-Cookie', '...sessioncookie...');
    });
};
```
