### PR TITLE
[EventLoop] Changed StreamSelectLoop to use non-blocking behavior on tic...

### DIFF
--- a/src/React/EventLoop/StreamSelectLoop.php
+++ b/src/React/EventLoop/StreamSelectLoop.php
@@ -122,19 +122,23 @@ class StreamSelectLoop implements LoopInterface
         }
     }
 
-    protected function runStreamSelect()
+    protected function runStreamSelect($block)
     {
         $read = $this->readStreams ?: null;
         $write = $this->writeStreams ?: null;
         $except = null;
 
         if (!$read && !$write) {
-            $this->sleepOnPendingTimers();
+            if ($block) {
+                $this->sleepOnPendingTimers();
+            }
 
             return;
         }
 
-        if (stream_select($read, $write, $except, 0, $this->getNextEventTimeInMicroSeconds()) > 0) {
+        $timeout = $block ? $this->getNextEventTimeInMicroSeconds() : 0;
+
+        if (stream_select($read, $write, $except, 0, $timeout) > 0) {
             if ($read) {
                 foreach ($read as $stream) {
                     $listener = $this->readListeners[(int) $stream];
@@ -155,21 +159,23 @@ class StreamSelectLoop implements LoopInterface
         }
     }
 
-    public function tick()
+    protected function loop($block = true)
     {
         $this->timers->tick();
-        $this->runStreamSelect();
+        $this->runStreamSelect($block);
 
         return $this->running;
+    }
+
+    public function tick()
+    {
+        return $this->loop(false);
     }
 
     public function run()
     {
         $this->running = true;
-
-        while ($this->tick()) {
-            // NOOP
-        }
+        while ($this->loop());
     }
 
     public function stop()


### PR DESCRIPTION
I noticed the StreamSelectLoop does not exhibit the same non-blocking behavior as the LibEventLoop when using the `tick()` method.  I modified it to never block on `stream_select()` nor sleep on pending timers when using the `tick()` method and provided a new protected method for the internal `run()` loop.

The existing test for the StreamSelectLoop is quite bare, so I did not modify it.  If you would prefer, I will gladly add a test for this modification.
