### PR TITLE
[Stream][Buffer] Only check feof on some occasions

### DIFF
--- a/src/React/Stream/Buffer.php
+++ b/src/React/Stream/Buffer.php
@@ -21,11 +21,16 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         'file'    => '',
         'line'    => 0,
     );
+    private $meta;
 
     public function __construct($stream, LoopInterface $loop)
     {
         $this->stream = $stream;
         $this->loop = $loop;
+
+        if (is_resource($stream)) {
+            $this->meta = stream_get_meta_data($stream);
+        }
     }
 
     public function isWritable()
@@ -78,7 +83,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
     public function handleWrite()
     {
-        if (!is_resource($this->stream) || feof($this->stream)) {
+        if (!is_resource($this->stream) || ('generic_socket' === $this->meta['stream_type'] && feof($this->stream))) {
             $this->emit('error', array(new \RuntimeException('Tried to write to closed or invalid stream.')));
 
             return;


### PR DESCRIPTION
If a TCP endpoint triggers a socket close handshake the other endpoint is still allowed to send data if the connection is open and should send a closing handshake asap.
feof detected the socket was closed for reading but told the write buffer is was closed entirely.
We can't seem to determine the difference in PHP so we're only checking if it's a generic_socket which seems to satisfy the requirements.
