### PR TITLE
[Http] Allow multiple headers with the same name by allowing header values to be arrays

### DIFF
--- a/src/React/Http/Response.php
+++ b/src/React/Http/Response.php
@@ -78,9 +78,12 @@ class Response extends EventEmitter implements WritableStreamInterface
 
         foreach ($headers as $name => $value) {
             $name = str_replace(array("\r", "\n"), '', $name);
-            $value = str_replace(array("\r", "\n"), '', $value);
 
-            $data .= "$name: $value\r\n";
+            foreach ((array) $value as $val) {
+                $val = str_replace(array("\r", "\n"), '', $val);
+
+                $data .= "$name: $val\r\n";
+            }
         }
         $data .= "\r\n";
 

--- a/tests/React/Tests/Http/ResponseTest.php
+++ b/tests/React/Tests/Http/ResponseTest.php
@@ -163,4 +163,44 @@ class ResponseTest extends TestCase
         $response = new Response($conn);
         $response->writeHead(700);
     }
+
+    /** @test */
+    public function shouldAllowArrayHeaderValues()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.1 200 OK\r\n";
+        $expected .= "X-Powered-By: React/alpha\r\n";
+        $expected .= "Set-Cookie: foo=bar\r\n";
+        $expected .= "Set-Cookie: bar=baz\r\n";
+        $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn);
+        $response->writeHead(200, array("Set-Cookie" => array("foo=bar", "bar=baz")));
+    }
+
+    /** @test */
+    public function shouldIgnoreHeadersWithNullValues()
+    {
+        $expected = '';
+        $expected .= "HTTP/1.1 200 OK\r\n";
+        $expected .= "X-Powered-By: React/alpha\r\n";
+        $expected .= "Transfer-Encoding: chunked\r\n";
+        $expected .= "\r\n";
+
+        $conn = $this->getMock('React\Socket\ConnectionInterface');
+        $conn
+            ->expects($this->once())
+            ->method('write')
+            ->with($expected);
+
+        $response = new Response($conn);
+        $response->writeHead(200, array("FooBar" => null));
+    }
 }


### PR DESCRIPTION
This is especially required for Set-Cookie headers as multiple cookies must be sent as multiple headers.
Request header values are already parsed into arrays for multiple headers with the same name. This makes Response consistent with this behavior. 
