### PR TITLE
[Socket] Read raw stream when using Socket server (no stream)

### DIFF
--- a/src/React/Socket/Connection.php
+++ b/src/React/Socket/Connection.php
@@ -8,6 +8,8 @@ class Connection extends Stream implements ConnectionInterface
 {
     public function handleData($stream)
     {
+        // Socket is raw, not using fread is it's interceptable by filters
+        // See issues #192, #209, and #240
         $data = stream_socket_recvfrom($stream, $this->bufferSize);
         if ('' === $data || false === $data || feof($stream)) {
             $this->end();


### PR DESCRIPTION
Re-implementing #209 after a failed merge resolution by me where I favoured #192 instead. Socket server should be using raw socket data, not stream parsed data by using `fread`. 
