### PR TITLE
Stop HHVM build from hanging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
   allow_failures:
     - php: hhvm
 
-before_script:
-  - ./scripts/travis-init.sh
+install: ./scripts/travis-init.sh
 
 script: php vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
Some of the extensions were still being installed under the HHVM build, which seemed to be hanging the build.

This PR changes the travis-init.sh script so that extensions are only installed when building against the regular PHP interpreter. I also expanded commands onto multiple lines for the sake of readability - `set -e` ensures that the whole script fails if one command fails so that the commands do not need to be strung together with `&&`.

The HHVM build itself fails with fatal errors, but at least it actually get to the phpunit stage again now.
