### PR TITLE
No need to load the autoloader for something we're not going to use

### DIFF
--- a/examples/child-child.php
+++ b/examples/child-child.php
@@ -1,7 +1,5 @@
 <?php
 
-require __DIR__ . '/../vendor/autoload.php';
-
 $i = 0;
 
 // block all the things!


### PR DESCRIPTION
Since nothing in that file uses any user defined classes or functions there is no need to load an autoloader
