### PR TITLE
[EventLoop] Added check for non-empty next-tick queue in run()

### DIFF
--- a/src/React/EventLoop/ExtEventLoop.php
+++ b/src/React/EventLoop/ExtEventLoop.php
@@ -194,7 +194,7 @@ class ExtEventLoop implements LoopInterface
             $this->futureTickQueue->tick();
 
             $flags = EventBase::LOOP_ONCE;
-            if (!$this->running || !$this->futureTickQueue->isEmpty()) {
+            if (!$this->running || !$this->nextTickQueue->isEmpty() || !$this->futureTickQueue->isEmpty()) {
                 $flags |= EventBase::LOOP_NONBLOCK;
             } elseif (!$this->streamEvents && !$this->timerEvents->count()) {
                 break;

--- a/src/React/EventLoop/LibEvLoop.php
+++ b/src/React/EventLoop/LibEvLoop.php
@@ -198,7 +198,7 @@ class LibEvLoop implements LoopInterface
             $this->futureTickQueue->tick();
 
             $flags = EventLoop::RUN_ONCE;
-            if (!$this->running || !$this->futureTickQueue->isEmpty()) {
+            if (!$this->running || !$this->nextTickQueue->isEmpty() || !$this->futureTickQueue->isEmpty()) {
                 $flags |= EventLoop::RUN_NOWAIT;
             } elseif (!$this->readEvents && !$this->writeEvents && !$this->timerEvents->count()) {
                 break;

--- a/src/React/EventLoop/LibEventLoop.php
+++ b/src/React/EventLoop/LibEventLoop.php
@@ -202,7 +202,7 @@ class LibEventLoop implements LoopInterface
             $this->futureTickQueue->tick();
 
             $flags = EVLOOP_ONCE;
-            if (!$this->running || !$this->futureTickQueue->isEmpty()) {
+            if (!$this->running || !$this->nextTickQueue->isEmpty() || !$this->futureTickQueue->isEmpty()) {
                 $flags |= EVLOOP_NONBLOCK;
             } elseif (!$this->streamEvents && !$this->timerEvents->count()) {
                 break;

--- a/tests/React/Tests/EventLoop/AbstractLoopTest.php
+++ b/tests/React/Tests/EventLoop/AbstractLoopTest.php
@@ -320,6 +320,25 @@ abstract class AbstractLoopTest extends TestCase
         $this->loop->run();
     }
 
+    public function testNextTickEventGeneratedByFutureTick()
+    {
+        $stream = $this->createStream();
+
+        $this->loop->futureTick(
+            function () {
+                $this->loop->nextTick(
+                    function () {
+                        echo 'next-tick' . PHP_EOL;
+                    }
+                );
+            }
+        );
+
+        $this->expectOutputString('next-tick' . PHP_EOL);
+
+        $this->loop->run();
+    }
+
     public function testNextTickEventGeneratedByTimer()
     {
         $this->loop->addTimer(
@@ -414,6 +433,25 @@ abstract class AbstractLoopTest extends TestCase
             $stream,
             function () use ($stream) {
                 $this->loop->removeStream($stream);
+                $this->loop->futureTick(
+                    function () {
+                        echo 'future-tick' . PHP_EOL;
+                    }
+                );
+            }
+        );
+
+        $this->expectOutputString('future-tick' . PHP_EOL);
+
+        $this->loop->run();
+    }
+
+    public function testFutureTickEventGeneratedByNextTick()
+    {
+        $stream = $this->createStream();
+
+        $this->loop->nextTick(
+            function () {
                 $this->loop->futureTick(
                     function () {
                         echo 'future-tick' . PHP_EOL;


### PR DESCRIPTION
@cboden This commit should have been part of the original future-tick PR, I think I must have clobbered my own changes somewhere along the line.
