### PR TITLE
[EventLoop] Fix timeout in StreamSelectLoop

### DIFF
--- a/src/EventLoop/StreamSelectLoop.php
+++ b/src/EventLoop/StreamSelectLoop.php
@@ -194,8 +194,9 @@ class StreamSelectLoop implements LoopInterface
             } else {
                 break;
             }
-
-            $this->waitForStreamActivity($timeout * self::MICROSECONDS_PER_SECOND);
+            
+            $timeoutMs = ($timeout === null) ? null : $timeout * self::MICROSECONDS_PER_SECOND;
+            $this->waitForStreamActivity($timeoutMs);
         }
     }
 


### PR DESCRIPTION
Conversion from seconds to miliseconds changed null timeout (waiting forever) to 0 timeout (don't wait at all) which caused idle application to spin event loop wildly.

I noticed this bug only due to my rather poor CPU cooler.
