### PR TITLE
psr-0 should have been psr-4 when switching to it

### DIFF
--- a/src/Dns/composer.json
+++ b/src/Dns/composer.json
@@ -10,7 +10,7 @@
         "react/promise": "~2.0"
     },
     "autoload": {
-        "psr-0": { "React\\Dns\\": "" }
+        "psr-4": { "React\\Dns\\": "" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Ran into autoloading issues with the DNS component today, and it seem that when react switched to PSR4 two months ago someone forgot to change `psr-0` into `psr-4` like all other components.
