### PR TITLE
Update links to project meta repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <br>
 
 <div align="center">
-    <a href="https://travis-ci.org/reactphp/react"><img src="https://travis-ci.org/reactphp/react.svg?branch=master" alt="Build Status"></a>
+    <a href="https://travis-ci.org/reactphp/reactphp"><img src="https://travis-ci.org/reactphp/reactphp.svg?branch=master" alt="Build Status"></a>
 </div>
 
 <br>

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "homepage": "https://reactphp.org/",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/reactphp/react/issues",
         "chat": "https://gitter.im/reactphp/reactphp"
     },
     "require": {


### PR DESCRIPTION
This repository has been renamed from reactphp/react to reactphp/reactphp for consistency reasons, so the link to the Travis CI build also needs to be updated. This `composer.json` also contained a legacy reference to the issues in this repo, but we can simply omit this link because Packagist automatically links to the issues anyway (e.g. compare https://packagist.org/packages/react/react and https://packagist.org/packages/react/socket).

Builds on top of #432