### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ Streams abstraction, async DNS resolver, network client/server, HTTP
 client/server and interaction with processes. Third-party libraries can use these
 components to create async network clients/servers and more.
 
+```php
+$server = new React\Http\Server(function (Psr\Http\Message\ServerRequestInterface $request) {
+    return new React\Http\Message\Response(
+        200,
+        array(
+            'Content-Type' => 'text/plain'
+        ),
+        "Hello World!\n"
+    );
+});
+
+$socket = new React\Socket\Server('127.0.0.1:8080');
+$server->listen($socket);
+
+echo "Server running at http://127.0.0.1:8080" . PHP_EOL;
+```
+
+This simple web server written in ReactPHP responds with "Hello World!" for every request.
+
 ReactPHP is production ready and battle-tested with millions of installations
 from all kinds of projects around the world. Its event-driven architecture makes
 it a perfect fit for efficient network servers and clients handling hundreds or

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     "require": {
         "php": ">=5.3.8",
         "react/cache": "^1.0",
-        "react/dns": "^1.3",
-        "react/event-loop": "^1.0",
-        "react/http": "^1.0",
+        "react/dns": "^1.8",
+        "react/event-loop": "^1.2",
+        "react/http": "^1.4",
         "react/promise": "^2.1 || ^1.2",
         "react/promise-stream": "^1.1.1",
-        "react/promise-timer": "^1.6",
-        "react/socket": "^1.4",
-        "react/stream": "^1.0"
+        "react/promise-timer": "^1.7",
+        "react/socket": "^1.8",
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,10 +4,6 @@
     <testsuites>
         <testsuite name="ReactPHP Test Suite">
             <directory>./vendor/react/*/tests/</directory>
-            <!-- temporarily skip broken tests, see https://github.com/reactphp/dns/pull/164 -->
-            <exclude>./vendor/react/dns/tests/FunctionalResolverTest.php</exclude>
-            <exclude>./vendor/react/dns/tests/Query/CoopExecutorTest.php</exclude>
-            <exclude>./vendor/react/dns/tests/Query/SelectiveTransportExecutorTest.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,8 @@
     <testsuites>
         <testsuite name="ReactPHP Test Suite">
             <directory>./vendor/react/*/tests/</directory>
+            <!-- temporarily skip broken und unneeded tests, see https://github.com/reactphp/event-loop/pull/232 -->
+            <exclude>./vendor/react/event-loop/tests/BinTest.php</exclude>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
This changeset simplifies usage by updating to use the new [default loop](https://github.com/reactphp/event-loop#loop).

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/232, https://github.com/reactphp/socket/pull/260, https://github.com/reactphp/http/pull/410 and https://github.com/reactphp/website/pull/54