### PR TITLE
Update test suite to support PHPUnit 9

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,5 @@
 /.github/ export-ignore
 /.gitignore export-ignore
 /phpunit.xml.dist export-ignore
-/tests export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text --exclude-group internet
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text --exclude-group internet -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
@@ -38,5 +41,5 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
-      - run: hhvm $(which composer) require phpunit/phpunit:^5 --dev # requires legacy phpunit
+      - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit --exclude-group internet

--- a/composer.json
+++ b/composer.json
@@ -9,20 +9,20 @@
     },
     "require": {
         "php": ">=5.3.8",
-        "react/cache": "^1.0",
+        "react/cache": "^1.1",
         "react/dns": "^1.8",
         "react/event-loop": "^1.2",
         "react/http": "^1.6",
-        "react/promise": "^2.1 || ^1.2",
-        "react/promise-stream": "^1.1.1",
+        "react/promise": "^2.8 || ^1.2",
+        "react/promise-stream": "^1.3",
         "react/promise-timer": "^1.7",
         "react/socket": "^1.9",
         "react/stream": "^1.2"
     },
     "require-dev": {
-        "clue/block-react": "^1.1",
+        "clue/block-react": "^1.5",
         "clue/stream-filter": "^1.3",
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
     },
     "config": {
         "preferred-install": {

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.5+ -->
+<!-- PHPUnit configuration file with old PHPUnit format for PHP < 7.3 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         cacheResult="false"
          colors="true">
     <testsuites>
         <testsuite name="ReactPHP Test Suite">
@@ -15,9 +14,9 @@
             <exclude>./vendor/react/http/tests/HttpServerTest.php</exclude>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>./vendor/react/*/src/</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Builds on top of #449, #442, https://github.com/reactphp/promise/pull/163, https://github.com/reactphp/promise-stream/pull/24, https://github.com/reactphp/cache/pull/43 and others
Refs #446 as this should also unblock testing PHP 8.0 and PHP 8.1 in this meta project