### PR TITLE
Support PHP 8.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     "require": {
         "php": ">=5.3.8",
         "react/cache": "^1.1",
-        "react/dns": "^1.8",
+        "react/dns": "^1.9",
         "react/event-loop": "^1.2",
         "react/http": "^1.6",
-        "react/promise": "^2.8 || ^1.2",
+        "react/promise": "^2.9 || ^1.2",
         "react/promise-stream": "^1.3",
-        "react/promise-timer": "^1.7",
-        "react/socket": "^1.9",
+        "react/promise-timer": "^1.8",
+        "react/socket": "^1.11",
         "react/stream": "^1.2"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,12 +5,14 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          cacheResult="false"
-         colors="true">
+         colors="true"
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="ReactPHP Test Suite">
             <directory>./vendor/react/*/tests/</directory>
             <!-- temporarily skip broken und unneeded tests, see https://github.com/reactphp/event-loop/pull/232 -->
             <exclude>./vendor/react/event-loop/tests/BinTest.php</exclude>
+            <exclude>./vendor/react/event-loop/tests/ExtLibeventLoopTest.php</exclude>
             <!-- temporarily skip broken und unneeded tests, see https://github.com/reactphp/http/pull/440 -->
             <exclude>./vendor/react/http/tests/HttpServerTest.php</exclude>
         </testsuite>


### PR DESCRIPTION
Builds on top of #450, https://github.com/reactphp/dns/pull/188, https://github.com/reactphp/promise/pull/198, https://github.com/reactphp/promise-timer/pull/50, https://github.com/reactphp/socket/pull/277 and others
Refs https://github.com/reactphp/event-loop/pull/242 for skipped bogus test failure
Supersedes / closes #446