### PR TITLE
Update test suite to use new reactphp/async package instead of clue/reactphp-block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,16 @@
         "php": ">=5.3.8",
         "react/async": "^4 || ^3 || ^2",
         "react/cache": "^1.1",
-        "react/dns": "^1.9",
+        "react/dns": "^1.10",
         "react/event-loop": "^1.3",
-        "react/http": "^1.6",
+        "react/http": "^1.7",
         "react/promise": "^2.9 || ^1.2",
-        "react/promise-stream": "^1.3",
+        "react/promise-stream": "^1.5",
         "react/promise-timer": "^1.8",
-        "react/socket": "^1.11",
+        "react/socket": "^1.12",
         "react/stream": "^1.2"
     },
     "require-dev": {
-        "clue/block-react": "^1.5",
         "clue/stream-filter": "^1.3",
         "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,9 +9,9 @@
          convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="ReactPHP Test Suite">
+            <!-- explicitly run EventLoop tests first to avoid resetting default loop -->
+            <directory>./vendor/react/event-loop/tests/</directory>
             <directory>./vendor/react/*/tests/</directory>
-            <!-- temporarily skip broken und unneeded tests, see https://github.com/reactphp/http/pull/440 -->
-            <exclude>./vendor/react/http/tests/HttpServerTest.php</exclude>
         </testsuite>
     </testsuites>
     <coverage>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -8,8 +8,6 @@
     <testsuites>
         <testsuite name="ReactPHP Test Suite">
             <directory>./vendor/react/*/tests/</directory>
-            <!-- temporarily skip broken und unneeded tests, see https://github.com/reactphp/http/pull/440 -->
-            <exclude>./vendor/react/http/tests/HttpServerTest.php</exclude>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
Refs https://github.com/reactphp/dns/pull/206, https://github.com/reactphp/http/pull/464, https://github.com/reactphp/promise-stream/pull/32, https://github.com/reactphp/socket/pull/296 and https://github.com/clue/reactphp-block/issues/68
Builds on top of #458, #449 and https://github.com/reactphp/http/pull/440