### PR TITLE
Update test suite and report failed assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php:
@@ -24,11 +24,16 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+          ini-file: development
+          ini-values: disable_functions='' # do not disable PCNTL functions on PHP < 8.1
+          extensions: sockets, pcntl
+        env:
+          fail-fast: true # fail step if any extension can not be installed
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text --exclude-group internet
         if: ${{ matrix.php >= 7.3 }}
@@ -37,13 +42,16 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
+      - uses: actions/checkout@v3
+      - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
+      - name: Run hhvm composer.phar require react/async:^2 react/promise:^2 # downgrade Async and Promise for HHVM
+        uses: docker://hhvm/hhvm:3.30-lts-latest
         with:
-          version: lts-3.30
-      - run: composer self-update --2.2 # downgrade Composer for HHVM
-      - run: hhvm $(which composer) require react/async:^2 react/promise:^2 # downgrade Async and Promise for HHVM
-      - run: hhvm vendor/bin/phpunit --exclude-group internet
+          args: hhvm composer.phar require react/async:^2 react/promise:^2
+      - name: Run hhvm vendor/bin/phpunit --exclude-group internet
+        uses: docker://hhvm/hhvm:3.30-lts-latest
+        with:
+          args: hhvm vendor/bin/phpunit --exclude-group internet

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
         "php": ">=5.3.8",
         "react/async": "^4 || ^3 || ^2",
         "react/cache": "^1.1",
-        "react/dns": "^1.10",
-        "react/event-loop": "^1.3",
+        "react/dns": "^1.11",
+        "react/event-loop": "^1.4",
         "react/http": "^1.8",
-        "react/promise": "^3 || ^2.9 || ^1.2",
+        "react/promise": "^3 || ^2.10 || ^1.2",
         "react/promise-stream": "^1.5",
         "react/promise-timer": "^1.9",
-        "react/socket": "^1.12",
-        "react/stream": "^1.2"
+        "react/socket": "^1.13",
+        "react/stream": "^1.3"
     },
     "require-dev": {
         "clue/stream-filter": "^1.3",
-        "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     },
     "config": {
         "preferred-install": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.5+ -->
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          cacheResult="false"
          colors="true"
@@ -19,4 +19,12 @@
             <directory>./vendor/react/*/src/</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
+        <ini name="assert.active" value="1" />
+        <ini name="assert.exception" value="1" />
+        <ini name="assert.bail" value="0" />
+    </php>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old PHPUnit format for PHP < 7.3 -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
@@ -15,4 +15,12 @@
             <directory>./vendor/react/*/src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
+        <ini name="assert.active" value="1" />
+        <ini name="assert.exception" value="1" />
+        <ini name="assert.bail" value="0" />
+    </php>
 </phpunit>


### PR DESCRIPTION
Builds on top of #491, #455, #450, https://github.com/reactphp/socket/pull/299, https://github.com/reactphp/socket/pull/300 and https://github.com/reactphp/event-loop/pull/264.

~~Marking this as WIP because this is currently awaiting a number of releases. PRs https://github.com/reactphp/event-loop/pull/264, https://github.com/reactphp/promise/pull/241 and https://github.com/reactphp/stream/pull/165 need to be released to fix PHP 8.2 compatibility for the test suite, plus https://github.com/reactphp/socket/pull/299 for legacy HHVM. Additionally, PHP 8.1 and PHP 8.2 builds currently segfault, likely due to https://github.com/php/php-src/issues/10496 which should be fixed in PHP 8.2.4 (tagged just yesterday, not yet available through shivammathur/setup-php). I'll make sure to update this PR once releases are available.~~ [update 1: segfaults fixed with PHP 8.2.4 and PHP 8.1.17] [update 2: updated to all stable releases]