### PR TITLE
Update test environment to all stable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,26 +9,20 @@
     },
     "require": {
         "php": ">=5.3.8",
-        "react/async": "^4 || ^3 || ^2",
+        "react/async": "^4.2 || ^3.2 || ^2.2",
         "react/cache": "^1.1",
-        "react/dns": "^1.11",
+        "react/dns": "^1.12",
         "react/event-loop": "^1.4",
-        "react/http": "^1.8",
+        "react/http": "^1.10",
         "react/promise": "^3 || ^2.10 || ^1.3",
-        "react/promise-stream": "^1.6",
-        "react/promise-timer": "^1.9",
-        "react/socket": "^1.13",
+        "react/promise-stream": "^1.7",
+        "react/promise-timer": "^1.10",
+        "react/socket": "^1.14",
         "react/stream": "^1.3"
     },
     "require-dev": {
         "clue/stream-filter": "^1.3",
-        "phpunit/phpunit": "^9.6 || ^7.5 || ^5.7 || ^4.8.36",
-        "react/async": "^4.2@dev || ^3.2@dev || ^4 || ^3 || ^2",
-        "react/dns": "^1.12@dev",
-        "react/http": "^1.10@dev",
-        "react/promise-stream": "^1.7@dev",
-        "react/promise-timer": "^1.10@dev",
-        "react/socket": "^1.14@dev"
+        "phpunit/phpunit": "^9.6 || ^7.5 || ^5.7 || ^4.8.36"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
This changeset updates the test environment to all stable dependencies.

Builds on top of #545, #524 and the PRs linked there:

* https://github.com/reactphp/promise/pull/248 and https://github.com/reactphp/promise/pull/246
* https://github.com/reactphp/async/pull/79 and https://github.com/reactphp/async/pull/80
* https://github.com/reactphp/dns/pull/215
* https://github.com/reactphp/promise-stream/pull/37
* https://github.com/reactphp/promise-timer/pull/66
* https://github.com/reactphp/socket/pull/307
* https://github.com/reactphp/http/pull/501
* https://github.com/reactphp/socket/pull/308
* https://github.com/reactphp/promise-stream/pull/38