### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
     },
     "require": {
         "php": ">=5.3.8",
-        "react/async": "^4.2 || ^3.2 || ^2.2",
+        "react/async": "^4.3 || ^3.2 || ^2.2",
         "react/cache": "^1.1",
-        "react/dns": "^1.12",
-        "react/event-loop": "^1.4",
-        "react/http": "^1.10",
-        "react/promise": "^3 || ^2.10 || ^1.3",
+        "react/dns": "^1.13",
+        "react/event-loop": "^1.5",
+        "react/http": "^1.11",
+        "react/promise": "^3.2 || ^2.10 || ^1.3",
         "react/promise-stream": "^1.7",
-        "react/promise-timer": "^1.10",
-        "react/socket": "^1.14",
-        "react/stream": "^1.3"
+        "react/promise-timer": "^1.11",
+        "react/socket": "^1.15",
+        "react/stream": "^1.4"
     },
     "require-dev": {
         "clue/stream-filter": "^1.3",


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

Builds on top of
* #567
* #557 
* https://github.com/reactphp/promise/pull/260
* https://github.com/reactphp/stream/pull/179
* https://github.com/reactphp/dns/pull/224
* https://github.com/reactphp/promise-timer/pull/70
* https://github.com/reactphp/async/pull/87
* https://github.com/reactphp/socket/pull/318
* https://github.com/reactphp/http/pull/537
* https://github.com/reactphp/promise/pull/261
* https://github.com/reactphp/event-loop/pull/269
